### PR TITLE
Database-Seeding

### DIFF
--- a/Migrations/20241119120805_SeedData.Designer.cs
+++ b/Migrations/20241119120805_SeedData.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PRO05_backend_riley_tanya_dani_levi.Data;
@@ -11,9 +12,11 @@ using PRO05_backend_riley_tanya_dani_levi.Data;
 namespace PRO05_backend_riley_tanya_dani_levi.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241119120805_SeedData")]
+    partial class SeedData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20241119120805_SeedData.cs
+++ b/Migrations/20241119120805_SeedData.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace PRO05_backend_riley_tanya_dani_levi.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Users",
+                columns: new[] { "Id", "CreatedAt", "Email", "PasswordHash", "Username" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2024, 11, 19, 12, 8, 4, 695, DateTimeKind.Utc).AddTicks(9430), "john.doe@example.com", "Foodie123", "John Doe" },
+                    { 2, new DateTime(2024, 11, 19, 12, 8, 4, 695, DateTimeKind.Utc).AddTicks(9430), "jane.smith@example.com", "Burgers345", "Jane Smith" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Recipes",
+                columns: new[] { "Id", "CookingTime", "CreatedAt", "Description", "Ingredients", "IsPublic", "Title", "UpdatedAt", "UserId" },
+                values: new object[,]
+                {
+                    { 1, 30, new DateTime(2024, 11, 19, 12, 8, 4, 695, DateTimeKind.Utc).AddTicks(9690), "A classic Italian pasta dish.", "Spaghetti, minced beef, tomato sauce, onions, garlic", true, "Spaghetti Bolognese", new DateTime(2024, 11, 19, 12, 8, 4, 695, DateTimeKind.Utc).AddTicks(9690), 1 },
+                    { 2, 15, new DateTime(2024, 11, 19, 12, 8, 4, 695, DateTimeKind.Utc).AddTicks(9690), "A quick and healthy stir fry.", "Mixed vegetables, soy sauce, garlic, ginger", true, "Vegetable Stir Fry", new DateTime(2024, 11, 19, 12, 8, 4, 695, DateTimeKind.Utc).AddTicks(9690), 2 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Recipes",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Recipes",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2);
+        }
+    }
+}

--- a/data/AppDbContext.cs
+++ b/data/AppDbContext.cs
@@ -21,8 +21,13 @@ namespace PRO05_backend_riley_tanya_dani_levi.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            // User to Recipes relationship
-            modelBuilder.Entity<User>()
+                base.OnModelCreating(modelBuilder);
+
+
+                // Define the relationships first, always:
+
+
+                modelBuilder.Entity<User>()
                 .HasMany(u => u.Recipes)
                 .WithOne(r => r.User)
                 .HasForeignKey(r => r.UserId)
@@ -42,12 +47,60 @@ namespace PRO05_backend_riley_tanya_dani_levi.Data
                 .HasForeignKey(cr => cr.CollectionId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            // Recipe to CollectionRecipes relationship
             modelBuilder.Entity<Recipe>()
                 .HasMany(r => r.CollectionRecipes)
                 .WithOne(cr => cr.Recipe)
                 .HasForeignKey(cr => cr.RecipeId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+
+            // User to Recipes relationship seeds
+            modelBuilder.Entity<User>().HasData(
+                new User 
+                {
+                    Id = 1,
+                    Username = "John Doe", // Example property
+                    Email = "john.doe@example.com",
+                    PasswordHash = "Foodie123",
+                    CreatedAt = DateTime.UtcNow,
+                },
+                new User 
+                {
+                    Id = 2,
+                    Username = "Jane Smith", // Example property
+                    Email = "jane.smith@example.com",
+                    PasswordHash = "Burgers345",
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+
+            // Recipe to CollectionRecipes relationship seeds 
+            modelBuilder.Entity<Recipe>().HasData(
+                new Recipe
+                {
+                    Id = 1,
+                    UserId = 1, 
+                    Title = "Spaghetti Bolognese",
+                    Ingredients = "Spaghetti, minced beef, tomato sauce, onions, garlic",
+                    Description = "A classic Italian pasta dish.",
+                    IsPublic = true,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                    CookingTime = 30
+                }, 
+                new Recipe {
+                    Id = 2,
+                    UserId = 2,
+                    Title = "Vegetable Stir Fry",
+                    Ingredients = "Mixed vegetables, soy sauce, garlic, ginger",
+                    Description = "A quick and healthy stir fry.",
+                    IsPublic = true,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                    CookingTime = 15
+                }
+            );
         }
     }
 }
+

--- a/models/Recipe.cs
+++ b/models/Recipe.cs
@@ -30,7 +30,7 @@ public class Recipe
 
     // Navigation properties
     [ForeignKey(nameof(UserId))]
-    public required User User { get; set; }
+    public  User User { get; set; }
 
     public ICollection<CollectionRecipe>? CollectionRecipes { get; set; }
 }

--- a/models/Recipe.cs
+++ b/models/Recipe.cs
@@ -30,7 +30,7 @@ public class Recipe
 
     // Navigation properties
     [ForeignKey(nameof(UserId))]
-    public  User User { get; set; }
+    public  User? User { get; set; }
 
     public ICollection<CollectionRecipe>? CollectionRecipes { get; set; }
 }


### PR DESCRIPTION
Hey Team, 

### Pull Request Summary:

Seed Data for User and Recipe Models:
> - Seeded initial mock data for User and Recipe models in AppDbContext using the HasData() method.
Ensured the User table is seeded before the Recipe table to ensure valid UserId references.

> - Fixed Relationship Between User and Recipe:
Updated the Recipe seeding to reference UserId directly (instead of setting the User navigation property), aligning with how Entity Framework handles relationships using foreign keys.

> - Addressed Nullable Navigation Property Error:
Resolved CS8618 error by ensuring that UserId is set correctly during the seeding process for Recipe, thus satisfying the required foreign key constraint.


### Detailed Changes:

> - User Data Seeding:
Seeded two users, John Doe and Jane Smith, with mock data (ID, Username, Email, PasswordHash, and CreatedAt).

> - Recipe Data Seeding:

Seeded two recipes, each linked to a user via UserId (instead of the User navigation property).
Mock data for recipes includes Title, Ingredients, Description, IsPublic, CookingTime, and timestamps (CreatedAt, UpdatedAt).

> - Fixed Navigation Property Handling:

Corrected foreign key reference between User and Recipe by using UserId in the Recipe data.

Ensured that the User navigation property does not need to be manually set during seeding as EF handles the relationship automatically based on the UserId foreign key.

> - Confirmed Foreign Key Relationship:

Confirmed that OnDelete(DeleteBehavior.Cascade) is correctly set for the relationship between User and Recipe, ensuring cascading deletes.
